### PR TITLE
P9 #61 - Roster PDF: cover sheet only when project has no sites Dileep

### DIFF
--- a/CityWatch.Web/Services/RosterReportGenerator.cs
+++ b/CityWatch.Web/Services/RosterReportGenerator.cs
@@ -80,7 +80,14 @@ namespace CityWatch.Web.Services
             var group = await _context.RosterGroups.FindAsync(groupId);
             if (group == null) return null;
 
-            byte[] rosterBytes = await GenerateSingleProjectRosterPartAsync(groupId, startDate, weeks, includeFinancials, includeSuppliers, rateType);
+            // P9 Issue 61: a project with no sites allocated must produce only its cover
+            // sheet — skip the empty roster card page. When there is no cover sheet either,
+            // keep the previous behaviour so the download still returns a document.
+            var hasSites = await _context.RosterGroupSites.AnyAsync(x => x.RosterGroupId == groupId);
+
+            byte[] rosterBytes = (hasSites || string.IsNullOrEmpty(group.CoverFileName))
+                ? await GenerateSingleProjectRosterPartAsync(groupId, startDate, weeks, includeFinancials, includeSuppliers, rateType)
+                : null;
 
             if (string.IsNullOrEmpty(group.CoverFileName))
             {
@@ -265,8 +272,17 @@ namespace CityWatch.Web.Services
                         }
 
                         // 2b. Project Roster
-                        byte[] partBytes = await GenerateSingleProjectRosterPartAsync(bp.RosterGroupId, startDate, weeks, includeFinancials, includeSuppliers, rateType);
-                        AddBytesToMerger(merger, partBytes);
+                        // P9 Issue 61: skip the empty roster card page for projects with no
+                        // sites allocated when a cover sheet (group or project) is present.
+                        // Without any cover sheet, keep the previous behaviour so the merged
+                        // document is never empty.
+                        var projectHasSites = await _context.RosterGroupSites.AnyAsync(x => x.RosterGroupId == bp.RosterGroupId);
+                        bool hasAnyCover = !string.IsNullOrEmpty(binder.CoverFileName) || !string.IsNullOrEmpty(bp.RosterGroup.CoverFileName);
+                        if (projectHasSites || !hasAnyCover)
+                        {
+                            byte[] partBytes = await GenerateSingleProjectRosterPartAsync(bp.RosterGroupId, startDate, weeks, includeFinancials, includeSuppliers, rateType);
+                            AddBytesToMerger(merger, partBytes);
+                        }
                     }
                     merger.Close();
                 }


### PR DESCRIPTION
## Project 9 - Roster R&D Diary - Issue 61 (Blank Page Issue)

**Requirement (client):** Downloading the roster PDF for a PROJECT or GROUP that has **no sites allocated** must produce only the cover sheet - currently an empty roster card page ("Roster: ADHOC" with a zero-total table) is added behind the cover sheet.

## Change
- `RosterReportGenerator.GenerateRosterPdfAsync` (Project download): when the project has no `RosterGroupSites` and a cover sheet exists, the roster part is skipped - the PDF contains the cover sheet only.
- `RosterReportGenerator.GenerateBinderRosterPdfAsync` (Group download): per project in the binder, the roster part is skipped when that project has no sites and a cover (group or project) is present.
- When no cover sheet exists at all, previous behaviour is kept so the download never produces an empty/invalid document.

## Testing
- Project with sites: PDF unchanged (cover + roster pages).
- Project with no sites + cover: PDF = cover sheet only.
- Project with no sites + no cover: unchanged (empty card, as before).
- Group: mixed projects - projects with sites keep roster pages; site-less projects contribute cover only.

Build verified (`dotnet build`, 0 errors - note: pre-existing unrelated Razor error in `_KeyVehicleLogPopup.cshtml` on master, not touched by this PR).

?? Generated with [Claude Code](https://claude.com/claude-code)