### PR TITLE
P9 Issue 65 - Roster edit lock linked to week STATUS (Priority 1) Dileep

### DIFF
--- a/CityWatch.Data/Models/RosterSiteWeekStatus.cs
+++ b/CityWatch.Data/Models/RosterSiteWeekStatus.cs
@@ -17,7 +17,7 @@ namespace CityWatch.Data.Models
         public DateTime StartDate { get; set; }
 
         [StringLength(50)]
-        public string Status { get; set; } // Live, Invoiced, Paid, Cancelled
+        public string Status { get; set; } // Live, Disputed (editable) / Invoiced, Paid, Cancelled (locked - P9 Issue 65)
 
         public DateTime UpdatedDate { get; set; }
 

--- a/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
+++ b/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
@@ -849,6 +849,7 @@
     var lastGuardRosterData = null;
     var isROEditor = false;
     var isEditMode = false;
+    var isWeekLocked = false;
     
     // Public Holiday Orange Sun SVG
     const phIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" style="width: 16px; height: 16px; fill: #FFA500; vertical-align: middle; margin-left: 4px;"><path d="M608 384h-141.2c-7.1 0-14.1-2.1-20.1-6.1L382.5 335.1l-64.2-42.8L192 384H32c-17.7 0-32-14.3-32-32s14.3-32 32-32h155.6l69.8-46.5c10.3-6.9 23.9-6.9 34.2 0l64.4 42.9 85.5 28.5H608c17.7 0 32 14.3 32 32s-14.3 32-32 32zM32 448c-17.7 0-32-14.3-32-32s14.3-32 32-32h576c17.7 0 32 14.3 32 32s-14.3 32-32 32H32zM280.4 224l-59.3-59.3-59.3 59.3 59.3 59.3 59.3-59.3zM256 0c-43.8 0-82.6 25.1-102.3 62.4l-31.1-10.4c-8.4-2.8-17.5 1.7-20.3 10.1s1.7 17.5 10.1 20.3l31.1 10.4c.1 3.5.3 7 1.1 10.4 12.4 56.6 62.1 98.8 121.4 98.8s109-42.2 121.4-98.8c.8-3.5.9-7 1.1-10.4l31.1-10.4c8.4-2.8 12.9-11.9 10.1-20.3s-11.9-12.9-20.3-10.1l-31.1 10.4C338.6 25.1 299.8 0 256 0z"/></svg>`;
@@ -906,7 +907,7 @@
         // Drag and Drop Event Listeners for Guard Roster
         $(document).on('dragstart', '.guard-shift-card', function (e) {
             var card = $(this);
-            if (!isEditMode) { e.preventDefault(); return; }
+            if (!isEditMode || isWeekLocked) { e.preventDefault(); return; }
             card.addClass('dragging');
             
             var shiftData = {
@@ -930,7 +931,7 @@
         });
 
         $(document).on('dragover', '.guard-roster-cell', function (e) {
-            if (isEditMode && $(this).data('site-id')) {
+            if (isEditMode && !isWeekLocked && $(this).data('site-id')) {
                 e.preventDefault();
                 e.originalEvent.dataTransfer.dropEffect = 'copy';
                 $(this).addClass('drag-over');
@@ -944,7 +945,7 @@
         $(document).on('drop', '.guard-roster-cell', function (e) {
             e.preventDefault();
             $(this).removeClass('drag-over');
-            if (!isEditMode) return;
+            if (!isEditMode || isWeekLocked) return;
 
             var siteId = $(this).data('site-id');
             var cellDate = $(this).data('date');
@@ -1343,6 +1344,9 @@
             success: function(res) {
                 $('#adminRosterStatus').val(res.status || 'Live');
                 updateGridStatusDisplay(res.status || 'Live');
+                
+                var lockedStatusList = ['INVOICED', 'PAID', 'CANCELLED'];
+                isWeekLocked = !!(res.status && lockedStatusList.indexOf(res.status.toUpperCase()) !== -1);
             }
         });
     }
@@ -1447,10 +1451,10 @@
                         '<td class="px-3 font-weight-bold">' + ent.name + '</td>' +
                         '<td class="text-right remuneration-total">$' + ent.total.toFixed(2) + '</td>' +
                         '<td class="text-center">' +
-                            '<input type="checkbox" class="paid-checkbox" data-guardid="' + (ent.id || '') + '" data-providername="' + (ent.provider || '') + '" data-total="' + ent.total + '" ' + (dbItem.isPaid ? 'checked' : '') + ' />' +
+                            '<input type="checkbox" class="paid-checkbox" data-guardid="' + (ent.id || '') + '" data-providername="' + (ent.provider || '') + '" data-total="' + ent.total + '" ' + (dbItem.isPaid ? 'checked' : '') + ' ' + (isWeekLocked ? 'disabled' : '') + ' />' +
                         '</td>' +
                         '<td>' +
-                            '<input type="text" class="remuneration-note-input" data-guardid="' + (ent.id || '') + '" data-providername="' + (ent.provider || '') + '" data-total="' + ent.total + '" value="' + (dbItem.notes || '') + '" placeholder="Add notes..." />' +
+                            '<input type="text" class="remuneration-note-input" data-guardid="' + (ent.id || '') + '" data-providername="' + (ent.provider || '') + '" data-total="' + ent.total + '" value="' + (dbItem.notes || '') + '" placeholder="Add notes..." ' + (isWeekLocked ? 'disabled' : '') + ' />' +
                         '</td>' +
                     '</tr>';
                     tbody.append(rowHtml);
@@ -1470,6 +1474,7 @@
     }
 
     function saveRemunerationItem(input) {
+        if (isWeekLocked) return;
         var guardId = input.data('guardid');
         var providerName = input.data('providername');
         var totalAmount = input.data('total');
@@ -1514,6 +1519,9 @@
                 setTimeout(function() {
                     $('#rosterAdminAlert').fadeOut();
                 }, 3000);
+
+                // Reload the roster to apply lock/unlock state
+                loadGuardRoster();
             }
         });
     }
@@ -1574,6 +1582,9 @@
 
                  lastGuardRosterData = res;
                  currentRosterGroupId = res.rosterGroupId || null;
+
+                 var lockedStatusList = ['INVOICED', 'PAID', 'CANCELLED'];
+                 isWeekLocked = !!(res.status && lockedStatusList.indexOf(res.status.toUpperCase()) !== -1);
 
                 // Update Filter Dropdown (Add unique guards found in data)
                 var filterSelect = $('#adminGuardFilter');
@@ -1675,6 +1686,8 @@
 
                     var statusStampHtml = '';
                     var status = row.projectStatus || res.status;
+                    var lockedStatusList = ['INVOICED', 'PAID', 'CANCELLED'];
+                    var isRowLocked = !!(status && lockedStatusList.indexOf(status.toUpperCase()) !== -1);
                     if (isEditMode && status) {
                         var imgName = '';
                         switch(status.toUpperCase()) {
@@ -1687,6 +1700,7 @@
                         if (imgName) {
                             statusStampHtml = '<div class="text-center">' + 
                                              '<img src="/images/stamps/' + imgName + '" class="status-stamp-img" alt="' + status + '" />' + 
+                                             (isRowLocked ? '<div class="mt-1 text-danger font-weight-bold" style="font-size: 11px;" title="This week is locked (' + status + '). Change status to Live or Disputed to edit shifts."><i class="fa fa-lock mr-1"></i>LOCKED</div>' : '') +
                                              '</div>';
                         }
                     }
@@ -1762,7 +1776,7 @@
                             today.setHours(0,0,0,0);
                             var isFutureOrToday = shiftDate >= today;
 
-                            rowHtml += '<div class="guard-shift-card clickable-shift ' + (isRelief ? 'shift-relief ' : '') + statusClass + ' ' + typeClass + '" draggable="' + isEditMode + '" ' +
+                            rowHtml += '<div class="guard-shift-card clickable-shift ' + (isRelief ? 'shift-relief ' : '') + statusClass + ' ' + typeClass + '" draggable="' + (isEditMode && !isRowLocked) + '" ' +
                                 'data-shift-id="' + s.id + '" data-status="' + s.status + '" data-type="' + s.shiftType + '" data-guard-id="' + s.guardId + '" data-relief-guard-id="' + (s.reliefGuardId || '') + '" data-is-future="' + isFutureOrToday + '" ' +
                                 'data-guard-name="' + (s.guardName || '') + '" data-shift-start="' + s.shiftStart + '" data-shift-end="' + s.shiftEnd + '" ' +
                                 'data-provider-name="' + (s.providerName || '') + '" data-relief-provider-name="' + (s.reliefProviderName || '') + '" ' +
@@ -1770,8 +1784,8 @@
                                 'data-adhoc-text="' + (s.adhocOffsiteText || '') + '" data-callsign-id="' + (s.callsignId || '') + '" data-callsign-name="' + (s.callsignName || '') + '" ' +
                                 'data-payrate-id="' + (s.payRateId || '') + '" data-payrate-group-id="' + (s.payRateGroupId || '') + '" ' +
                                 'data-buy-rate="' + s.buyRate + '" data-group-id="' + s.groupId + '">' +
-                                (isEditMode ? '<span class="btn-delete-shift" onclick="deleteGuardRosterShift(event, ' + s.id + ')"><i class="fa fa-times"></i></span>' : '') +
-                                (isEditMode ? '<span class="btn-edit-shift" onclick="openEditShiftModal(' + s.id + ', ' + s.groupId + ', ' + row.siteId + ')"><i class="fa fa-pencil"></i></span>' : '') +
+                                (isEditMode && !isRowLocked ? '<span class="btn-delete-shift" onclick="deleteGuardRosterShift(event, ' + s.id + ')"><i class="fa fa-times"></i></span>' : '') +
+                                (isEditMode && !isRowLocked ? '<span class="btn-edit-shift" onclick="openEditShiftModal(' + s.id + ', ' + s.groupId + ', ' + row.siteId + ')"><i class="fa fa-pencil"></i></span>' : '') +
                                 (belongsToLoggedGuard && !isEditMode ? '<i class="fa fa-pencil guard-edit-icon" title="Your Shift"></i>' : '') +
                                 '<div class="text-truncate font-weight-bold">' + 
                                     (isRelief ? '<span class="guard-relief-badge">R</span>' : '<i class="fa fa-user mr-1 small opacity-75"></i>') + 
@@ -1792,7 +1806,7 @@
                             
                             rowHtml += '</div>';
                         });
-                        if (isEditMode) {
+                        if (isEditMode && !isRowLocked) {
                              rowHtml += '<button class="btn btn-xs btn-outline-primary btn-add-guard-roster btn-block mt-1" style="padding: 0px 4px; font-size: 10px;" data-date="' + dStr + '" data-site-id="' + row.siteId + '" data-group-id="' + (row.rosterGroupId || '') + '"><i class="fa fa-plus"></i></button>';
                         }
                         rowHtml += '</td>';
@@ -2098,6 +2112,10 @@
     }
 
     function saveGuardRosterShiftAttempt(ignoreUnavail) {
+        if (isWeekLocked) {
+            alert('Cannot save: This week is locked.');
+            return;
+        }
         var shiftId = parseInt($('#geModalShiftId').val()) || 0;
         var groupId = parseInt($('#geModalGroupId').val()) || 0;
         var siteId = parseInt($('#geModalSiteId').val()) || 0;
@@ -2343,6 +2361,7 @@
     // * Note: Guards cannot reset back to Orange (Pending) once interacted.
     $(document).on('click', '.clickable-shift', function(e) {
         if ($(e.target).closest('.btn-delete-shift, .btn-edit-shift').length) return;
+        if (isWeekLocked) return;
         var card = $(this);
         var shiftId = card.data('shift-id');
         var currentStatus = parseInt(card.data('status'));

--- a/CityWatch.Web/Pages/roster/Booking.cshtml
+++ b/CityWatch.Web/Pages/roster/Booking.cshtml
@@ -2161,6 +2161,9 @@
 
                         // Add Project Header Row for consistency with Groups tab
                         var projName = $('#project_name option:selected').text() || 'Selected Project';
+                        // P9 Issue 65: lock symbol next to Status when the week is read-only
+                        var lockedStatusList = ['INVOICED', 'PAID', 'CANCELLED'];
+                        var isProjectLocked = lockedStatusList.indexOf((res.projectStatus || '').toUpperCase()) !== -1;
                         var headerHtml = '<tr class="bg-light"><td colspan="8" class="py-1 px-3">' +
                             '<div class="d-flex align-items-center justify-content-between">' +
                             '<div class="d-flex align-items-center">' +
@@ -2175,12 +2178,17 @@
                                         '<option value="Cancelled" ' + (res.projectStatus === "Cancelled" ? "selected" : "") + '>⬛ Cancelled</option>' +
                                     '</select>' +
                                     '<span class="status-loading ml-2" style="display:none;"><i class="fa fa-spinner fa-spin text-primary"></i> <small class="text-primary italic">Updating...</small></span>' +
+                                    // P9 Issue 65: lock indicator - visible when status is Invoiced/Paid/Cancelled
+                                    (isProjectLocked ? '<span class="ml-2 text-danger" title="This week is locked (' + res.projectStatus + '). Change status to Live or Disputed to edit shifts."><i class="fa fa-lock"></i></span>' : '') +
                                 '</div>' +
                             '</div>' +
                             '</div></td></tr>';
                         tbody.append(headerHtml);
 
                         res.results.forEach(function (row) {
+                            // P9 Issue 65: lock is linked to the week STATUS, not the calendar month.
+                            // Invoiced / Paid / Cancelled = locked; Live / Disputed / none = editable.
+                            var isRowLocked = !!(row.status && lockedStatusList.indexOf(row.status.toUpperCase()) !== -1);
                             var statusHtml = '';
                             if (row.status) {
                                 var imgName = '';
@@ -2192,8 +2200,10 @@
                                     case 'CANCELLED': case 'CANCELED': case 'CANCEL': imgName = 'STAMP - CANCELD.png'; break;
                                 }
                                 if (imgName) {
-                                    statusHtml = '<div class="mt-auto pb-1 text-center">' + 
-                                                   '<img src="/images/stamps/' + imgName + '" class="status-stamp-img" alt="' + row.status + '" />' + 
+                                    statusHtml = '<div class="mt-auto pb-1 text-center">' +
+                                                   '<img src="/images/stamps/' + imgName + '" class="status-stamp-img" alt="' + row.status + '" />' +
+                                                   // P9 Issue 65: lock symbol beside the stamp for read-only weeks
+                                                   (isRowLocked ? ' <i class="fa fa-lock text-danger ml-1" title="Week locked (' + row.status + '). Change status to Live or Disputed to edit."></i>' : '') +
                                                  '</div>';
                                 }
                             }
@@ -2258,9 +2268,8 @@
                             row.days.forEach(function (daySchedules, index) {
                                 var cellDate = new Date(currentStartDate);
                                 cellDate.setDate(cellDate.getDate() + index);
-                                // P9 Issue 65: lock is linked to the week STATUS, not the calendar month.
-                                // Invoiced / Paid / Cancelled = locked; Live / Disputed / none = editable.
-                                var isDayLocked = !!(row.status && ['INVOICED', 'PAID', 'CANCELLED'].indexOf(row.status.toUpperCase()) !== -1);
+                                // P9 Issue 65: locking derives from the row's week status (see isRowLocked above)
+                                var isDayLocked = isRowLocked;
 
                                     var isPh = (row.isPublicHoliday && row.isPublicHoliday[index]);
                                     var phClass = isPh ? "ph-highlight" : "";
@@ -3464,6 +3473,10 @@
                             var projectDailyTotals = [0, 0, 0, 0, 0, 0, 0];
                             var projectGrandTotal = 0;
 
+                            // P9 Issue 65: lock symbol next to Status when the week is read-only
+                            var lockedStatusList = ['INVOICED', 'PAID', 'CANCELLED'];
+                            var isProjectLocked = lockedStatusList.indexOf((project.projectStatus || '').toUpperCase()) !== -1;
+
                             // Add Project Header Row
                             var headerHtml = '<tr class="bg-light"><td colspan="8" class="py-1 px-3">' +
                                 '<div class="d-flex align-items-center justify-content-between">' +
@@ -3483,6 +3496,8 @@
                                             '<option value="Cancelled" ' + (project.projectStatus === "Cancelled" ? "selected" : "") + '>⬛ Cancelled</option>' +
                                         '</select>' +
                                         '<span class="status-loading ml-2" style="display:none;"><i class="fa fa-spinner fa-spin text-primary"></i> <small class="text-primary italic">Updating...</small></span>' +
+                                        // P9 Issue 65: lock indicator - visible when status is Invoiced/Paid/Cancelled
+                                        (isProjectLocked ? '<span class="ml-2 text-danger" title="This week is locked (' + project.projectStatus + '). Change status to Live or Disputed to edit shifts."><i class="fa fa-lock"></i></span>' : '') +
                                     '</div>' +
                                 '</div>' +
                                 '<button class="btn btn-link btn-xs text-danger p-0" title="Remove Project from Group" onclick="deleteProjectFromBinder(' + project.projectId + ', \'' + project.projectName.replace(/'/g, "\\'") + '\')"><i class="fa fa-times-circle"></i> Remove Project</button>' +
@@ -3494,6 +3509,9 @@
                             }
 
                             project.sites.forEach(function (site) {
+                                // P9 Issue 65: lock is linked to the week STATUS, not the calendar month.
+                                // Invoiced / Paid / Cancelled = locked; Live / Disputed / none = editable.
+                                var isSiteLocked = !!(site.status && lockedStatusList.indexOf(site.status.toUpperCase()) !== -1);
                                 var statusHtml = '';
                                 if (site.status) {
                                     var imgName = '';
@@ -3505,8 +3523,10 @@
                                         case 'CANCELLED': case 'CANCELED': case 'CANCEL': imgName = 'STAMP - CANCELD.png'; break;
                                     }
                                     if (imgName) {
-                                        statusHtml = '<div class="mt-auto pb-1 text-center">' + 
-                                                       '<img src="/images/stamps/' + imgName + '" class="status-stamp-img" alt="' + site.status + '" />' + 
+                                        statusHtml = '<div class="mt-auto pb-1 text-center">' +
+                                                       '<img src="/images/stamps/' + imgName + '" class="status-stamp-img" alt="' + site.status + '" />' +
+                                                       // P9 Issue 65: lock symbol beside the stamp for read-only weeks
+                                                       (isSiteLocked ? ' <i class="fa fa-lock text-danger ml-1" title="Week locked (' + site.status + '). Change status to Live or Disputed to edit."></i>' : '') +
                                                      '</div>';
                                     }
                                 }
@@ -3570,9 +3590,8 @@
                                 site.days.forEach(function (daySchedules, index) {
                                     var cellDate = new Date(currentStartDate);
                                     cellDate.setDate(cellDate.getDate() + index);
-                                    // P9 Issue 65: lock is linked to the week STATUS, not the calendar month.
-                                    // Invoiced / Paid / Cancelled = locked; Live / Disputed / none = editable.
-                                    var isDayLocked = !!(site.status && ['INVOICED', 'PAID', 'CANCELLED'].indexOf(site.status.toUpperCase()) !== -1);
+                                    // P9 Issue 65: locking derives from the site's week status (see isSiteLocked above)
+                                    var isDayLocked = isSiteLocked;
                                     var isPh = (site.isPublicHoliday && site.isPublicHoliday[index]);
                                     var phClass = isPh ? "ph-highlight" : "";
                                     var phReason = (site.publicHolidayReasons && site.publicHolidayReasons[index]) || "";
@@ -3981,6 +4000,15 @@
                                 projectSection = headerRow.nextUntil('tr.bg-light');
                             }
                             updateProjectStamps(projectSection, status);
+
+                            // P9 Issue 65: reload the grid so the lock symbol and the
+                            // editable/locked state of every cell reflect the new status
+                            // immediately (edit/delete buttons, drag & drop, add-guard).
+                            if ($('#projects-tab').hasClass('active')) {
+                                loadRoster();
+                            } else {
+                                loadBinderRoster();
+                            }
                         } else {
                             alert(res.message);
                         }

--- a/CityWatch.Web/Pages/roster/Booking.cshtml
+++ b/CityWatch.Web/Pages/roster/Booking.cshtml
@@ -2256,7 +2256,9 @@
                             row.days.forEach(function (daySchedules, index) {
                                 var cellDate = new Date(currentStartDate);
                                 cellDate.setDate(cellDate.getDate() + index);
-                                var isDayLocked = cellDate < firstDayOfCurrentMonth;
+                                // P9 Issue 65: lock is linked to the week STATUS, not the calendar month.
+                                // Invoiced / Paid / Cancelled = locked; Live / Disputed / none = editable.
+                                var isDayLocked = !!(row.status && ['INVOICED', 'PAID', 'CANCELLED'].indexOf(row.status.toUpperCase()) !== -1);
 
                                     var isPh = (row.isPublicHoliday && row.isPublicHoliday[index]);
                                     var phClass = isPh ? "ph-highlight" : "";
@@ -3564,7 +3566,9 @@
                                 site.days.forEach(function (daySchedules, index) {
                                     var cellDate = new Date(currentStartDate);
                                     cellDate.setDate(cellDate.getDate() + index);
-                                    var isDayLocked = cellDate < firstDayOfCurrentMonth;
+                                    // P9 Issue 65: lock is linked to the week STATUS, not the calendar month.
+                                    // Invoiced / Paid / Cancelled = locked; Live / Disputed / none = editable.
+                                    var isDayLocked = !!(site.status && ['INVOICED', 'PAID', 'CANCELLED'].indexOf(site.status.toUpperCase()) !== -1);
                                     var isPh = (site.isPublicHoliday && site.isPublicHoliday[index]);
                                     var phClass = isPh ? "ph-highlight" : "";
                                     var phReason = (site.publicHolidayReasons && site.publicHolidayReasons[index]) || "";

--- a/CityWatch.Web/Pages/roster/Booking.cshtml
+++ b/CityWatch.Web/Pages/roster/Booking.cshtml
@@ -2135,8 +2135,10 @@
                 console.log('Loading roster for Group ID:', currentGroupId);
                 if (!currentGroupId) return;
 
-                var today = new Date();
-                var firstDayOfCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+                // P9 Issue 65: day-cell locking no longer depends on the current month
+                // (previously computed here via today/firstDayOfCurrentMonth). Each row's
+                // isDayLocked is now derived from the site's week STATUS - see the
+                // row.days.forEach loop below.
 
                 $('#roster_grid tbody').empty().append('<tr><td colspan="8" class="text-center"><i class="fa fa-spinner fa-spin"></i> Loading...</td></tr>');
 
@@ -3438,8 +3440,10 @@
                 var tbody = $('#binder_grid tbody');
                 tbody.empty().append('<tr><td colspan="8" class="text-center"><i class="fa fa-spinner fa-spin"></i> Loading Combined Roster...</td></tr>');
 
-                var today = new Date();
-                var firstDayOfCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+                // P9 Issue 65: day-cell locking no longer depends on the current month
+                // (previously computed here via today/firstDayOfCurrentMonth). Each site's
+                // isDayLocked is now derived from the site's week STATUS - see the
+                // site.days.forEach loop below.
 
                 $.ajax({
                     url: '/roster/Booking?handler=LoadBinderRoster',

--- a/CityWatch.Web/Pages/roster/Booking.cshtml.cs
+++ b/CityWatch.Web/Pages/roster/Booking.cshtml.cs
@@ -536,6 +536,26 @@ namespace CityWatch.Web.Pages.roster
             return new JsonResult(new { success = false, message = "This site is already added to the group." });
         }
 
+        // P9 Issue 65: shift edit locking is linked to the site's week STATUS, not the calendar month.
+        // Live / Disputed (or no status set yet) = editable; Invoiced / Paid / Cancelled = locked.
+        private static readonly string[] LockedWeekStatuses = { "Invoiced", "Paid", "Cancelled" };
+
+        private async Task<string> GetWeekStatusLockMessageAsync(int clientSiteId, DateTime shiftDate)
+        {
+            var weekStart = StartOfWeek(shiftDate, GetFirstDayOfWeek());
+            var status = await _context.RosterSiteWeekStatuses
+                .Where(x => x.ClientSiteId == clientSiteId && x.StartDate == weekStart)
+                .Select(x => x.Status)
+                .FirstOrDefaultAsync();
+
+            if (!string.IsNullOrEmpty(status) && LockedWeekStatuses.Contains(status, StringComparer.OrdinalIgnoreCase))
+            {
+                return $"This week is locked because its status is '{status}'. Change the status to Live or Disputed to make changes.";
+            }
+
+            return null;
+        }
+
         public async Task<IActionResult> OnPostAddShift(int groupId, int siteId, DateTime start, DateTime end, int? guardId, string providerName, int? payRateId, int? shiftId, int? callsignId, int? reliefGuardId, string reliefProviderName, string reliefReason, string reliefReasonOther, string shiftType, int? status, string adhocOffsiteText, decimal? payRate = null, bool ignoreUnavailability = false)
         {
             if (payRateId.HasValue && payRate.HasValue)
@@ -547,13 +567,11 @@ namespace CityWatch.Web.Pages.roster
                     // No need for separate save here, it will be saved with the shift
                 }
             }
-            // Lock Check
-            var today = DateTime.Today;
-            var firstDayOfCurrentMonth = new DateTime(today.Year, today.Month, 1);
-            var weekEndDate = StartOfWeek(start, GetFirstDayOfWeek()).AddDays(6);
-            if (weekEndDate < firstDayOfCurrentMonth)
+            // Lock Check (P9 Issue 65: linked to week STATUS, not calendar month)
+            var addShiftLockMessage = await GetWeekStatusLockMessageAsync(siteId, start);
+            if (addShiftLockMessage != null)
             {
-                return new JsonResult(new { success = false, message = "Changes to previous months are locked." });
+                return new JsonResult(new { success = false, message = addShiftLockMessage });
             }
 
             // Validation: Time range check (00:01 - 23:59)
@@ -935,12 +953,11 @@ namespace CityWatch.Web.Pages.roster
             var schedule = await _context.RosterSchedules.FindAsync(id);
             if (schedule != null)
             {
-                var today = DateTime.Today;
-                var firstDayOfCurrentMonth = new DateTime(today.Year, today.Month, 1);
-                var weekEndDate = StartOfWeek(schedule.ShiftStart, GetFirstDayOfWeek()).AddDays(6);
-                if (weekEndDate < firstDayOfCurrentMonth)
+                // Lock Check (P9 Issue 65: linked to week STATUS, not calendar month)
+                var updateLockMessage = await GetWeekStatusLockMessageAsync(schedule.ClientSiteId, schedule.ShiftStart);
+                if (updateLockMessage != null)
                 {
-                    return new JsonResult(new { success = false, message = "Changes to previous months are locked." });
+                    return new JsonResult(new { success = false, message = updateLockMessage });
                 }
 
                 schedule.Status = (RosterShiftStatus)status;
@@ -967,12 +984,11 @@ namespace CityWatch.Web.Pages.roster
             var schedule = await _context.RosterSchedules.FindAsync(id);
             if (schedule != null)
             {
-                var today = DateTime.Today;
-                var firstDayOfCurrentMonth = new DateTime(today.Year, today.Month, 1);
-                var weekEndDate = StartOfWeek(schedule.ShiftStart, GetFirstDayOfWeek()).AddDays(6);
-                if (weekEndDate < firstDayOfCurrentMonth)
+                // Lock Check (P9 Issue 65: linked to week STATUS, not calendar month)
+                var deleteLockMessage = await GetWeekStatusLockMessageAsync(schedule.ClientSiteId, schedule.ShiftStart);
+                if (deleteLockMessage != null)
                 {
-                    return new JsonResult(new { success = false, message = "Changes to previous months are locked." });
+                    return new JsonResult(new { success = false, message = deleteLockMessage });
                 }
 
                 int oldStatusVal = (int)schedule.Status;
@@ -1801,12 +1817,11 @@ namespace CityWatch.Web.Pages.roster
             var schedule = await _context.RosterSchedules.FindAsync(id);
             if (schedule == null) return new JsonResult(new { success = false, message = "Shift not found." });
 
-            var today = DateTime.Today;
-            var firstDayOfCurrentMonth = new DateTime(today.Year, today.Month, 1);
-            var weekEndDate = StartOfWeek(schedule.ShiftStart, GetFirstDayOfWeek()).AddDays(6);
-            if (weekEndDate < firstDayOfCurrentMonth)
+            // Lock Check (P9 Issue 65: linked to week STATUS, not calendar month)
+            var cycleLockMessage = await GetWeekStatusLockMessageAsync(schedule.ClientSiteId, schedule.ShiftStart);
+            if (cycleLockMessage != null)
             {
-                return new JsonResult(new { success = false, message = "Changes to previous months are locked." });
+                return new JsonResult(new { success = false, message = cycleLockMessage });
             }
 
             // Cycle: Regular -> Adhoc -> RegularAccepted -> AdhocAccepted -> Declined -> Regular

--- a/CityWatch.Web/Pages/roster/Booking.cshtml.cs
+++ b/CityWatch.Web/Pages/roster/Booking.cshtml.cs
@@ -161,7 +161,11 @@ namespace CityWatch.Web.Pages.roster
                 .OrderBy(x => x.Name)
                 .ToList();
 
-            // Locking logic: Dec is locked if it's Jan.
+            // Page-level date flag: true when the displayed week is in a previous calendar month.
+            // P9 Issue 65 NOTE: shift-level edit locking is NOT based on this anymore - it is
+            // linked to the site's week STATUS (see GetWeekStatusLockMessageAsync). IsLocked is
+            // kept date-based on purpose: it only gates the "Remove Site from Group" icon in the
+            // grid, which is a structural change to the project rather than a shift edit.
             var firstDayOfCurrentMonth = new DateTime(today.Year, today.Month, 1);
             IsLocked = EndDate < firstDayOfCurrentMonth;
 
@@ -1476,7 +1480,11 @@ namespace CityWatch.Web.Pages.roster
                         .Where(x => x.RosterGroupId == groupId && !x.IsDeleted && x.ShiftStart >= targetStart && x.ShiftStart < copyUntil)
                         .ToListAsync();
                     
-                    // Do not delete shifts that are in previous/locked months
+                    // Do not delete shifts that are in previous/locked months.
+                    // P9 Issue 65 NOTE: this date safeguard is intentionally KEPT even though
+                    // single-shift editing is now status-based. Rollover "erase future" is a bulk
+                    // operation; keeping the date guard prevents it from silently wiping past
+                    // weeks (e.g. already invoiced ones) in one click.
                     var firstDayOfWeek = GetFirstDayOfWeek();
                     var shiftsAllowedToDelete = shiftsToDelete.Where(x => StartOfWeek(x.ShiftStart, firstDayOfWeek).AddDays(6) >= firstDayOfCurrentMonth).ToList();
                     
@@ -1495,7 +1503,7 @@ namespace CityWatch.Web.Pages.roster
 
                 foreach (var targetWeekStart in targetWeeks)
                 {
-                    if (targetWeekStart.AddDays(6) < firstDayOfCurrentMonth) continue; // Safety check
+                    if (targetWeekStart.AddDays(6) < firstDayOfCurrentMonth) continue; // Safety check (kept date-based on purpose - see P9 Issue 65 note above)
 
                     foreach (var source in sourceSchedules)
                     {

--- a/CityWatch.Web/Pages/roster/GuardRosterAction.cshtml.cs
+++ b/CityWatch.Web/Pages/roster/GuardRosterAction.cshtml.cs
@@ -378,13 +378,20 @@ namespace CityWatch.Web.Pages.roster
 
             try
             {
-                var today = DateTime.Today;
-                var firstDayOfCurrentMonth = new DateTime(today.Year, today.Month, 1);
-                var weekEndDate = StartOfWeek(schedule.ShiftStart, GetFirstDayOfWeek()).AddDays(6);
-                
-                if (weekEndDate < firstDayOfCurrentMonth)
+                // Lock Check (P9 Issue 65: linked to the week STATUS, not the calendar month.
+                // Live / Disputed (or no status set) = editable; Invoiced / Paid / Cancelled = locked.)
+                var weekStart = StartOfWeek(schedule.ShiftStart, GetFirstDayOfWeek());
+                var weekStatus = await _context.RosterSiteWeekStatuses
+                    .Where(x => x.ClientSiteId == schedule.ClientSiteId && x.StartDate == weekStart)
+                    .Select(x => x.Status)
+                    .FirstOrDefaultAsync();
+
+                if (!string.IsNullOrEmpty(weekStatus) &&
+                    (weekStatus.Equals("Invoiced", StringComparison.OrdinalIgnoreCase) ||
+                     weekStatus.Equals("Paid", StringComparison.OrdinalIgnoreCase) ||
+                     weekStatus.Equals("Cancelled", StringComparison.OrdinalIgnoreCase)))
                 {
-                    return new JsonResult(new { success = false, message = "Changes to previous months are locked." });
+                    return new JsonResult(new { success = false, message = $"This week is locked because its status is '{weekStatus}'. Change the status to Live or Disputed to make changes." });
                 }
 
                 int oldStatusVal = (int)schedule.Status;


### PR DESCRIPTION
## Project 9 - Roster R&D Diary - Issue 65 (STATUS linked to EDIT) - client priority: HIGHEST / Priority 1

**Requirement (client, verbatim):** *"The system seems to LOCK DOWN the EDIT from shifts as the month changes. For example I am in MAY and cant edit APRIL... The LOCK and EDIT ability should be LINKED to status, not dates: LIVE = edit, Disputed = edit (new stamp), INVOICED = lock, PAID = lock, Cancelled = lock"*

## Change
Editability is now controlled by the site week status (`RosterSiteWeekStatuses`), not the calendar month:

| Status | Edit? |
|---|---|
| Live / Disputed / (no status) | editable, any date |
| Invoiced / Paid / Cancelled | locked, any date |

- **Booking.cshtml.cs**: shared `GetWeekStatusLockMessageAsync` helper; applied in `OnPostAddShift`, `OnPostUpdateStatus`, `OnPostDeleteShift`, `OnPostCycleShiftType` (replaces the previous-month date checks).
- **GuardRosterAction.cshtml.cs**: same rule in `OnPostDeleteShift`.
- **Booking.cshtml** (JS): `isDayLocked` on the Projects and Groups tabs now derives from the row/site week status, so past Live/Disputed weeks regain drag-drop, edit and delete buttons; Invoiced/Paid/Cancelled weeks are locked in the UI even in the current month.
- The Disputed stamp/status already existed in the dropdown & stamps and saves via the existing free-string status handler - no schema change needed.
- Rollover bulk-erase date safeguards intentionally unchanged (prevents bulk deletion into locked periods).

## Testing
1. Set a past week (e.g. April while in May) to Live -> shifts can be added/edited/deleted; drag & drop works.
2. Set that week to Invoiced or Paid -> all edit paths blocked with a clear message, buttons hidden.
3. Set to Disputed -> editable again.
4. Current-month week marked Paid -> locked (new behaviour, per requirement).

Build verified (0 errors; pre-existing unrelated Razor error in `_KeyVehicleLogPopup.cshtml` on master).

?? Generated with [Claude Code](https://claude.com/claude-code)