### PR TITLE
P9#68 - Roster popup: Callsign filter + PDF respects guard/cal Dileep

### DIFF
--- a/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
+++ b/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
@@ -446,22 +446,19 @@
                             </select>
                         </div>
 
-                        <!-- Guard Filter Control [NEW] -->
-                        <div class="input-group input-group-sm ml-2" style="width: 150px;">
+                        <!-- Guard Filter Control [NEW] - icon only, no "FILTER" text -->
+                        <div class="input-group input-group-sm ml-2" style="width: 130px;" title="Filter by Guard">
                             <div class="input-group-prepend">
-                                <span class="input-group-text bg-white border-right-0 text-muted small font-weight-bold"><i class="fa fa-filter mr-1"></i> FILTER</span>
+                                <span class="input-group-text bg-white border-right-0 text-muted small font-weight-bold"><i class="fa fa-filter"></i></span>
                             </div>
                             <select id="adminGuardFilter" class="form-control font-weight-bold" style="font-size: 10px; height: 32px; border-left: 0;">
                                 <option value="ALL">ALL GUARDS</option>
                             </select>
                         </div>
 
-                        <!-- Callsign Filter Control [NEW - Issue 68] -->
-                        <div class="input-group input-group-sm ml-2" style="width: 150px;" title="Filter by Callsign">
-                            <div class="input-group-prepend">
-                                <span class="input-group-text bg-white border-right-0 text-muted small font-weight-bold"><i class="fa fa-microphone"></i></span>
-                            </div>
-                            <select id="adminCallsignFilter" class="form-control font-weight-bold" style="font-size: 10px; height: 32px; border-left: 0;">
+                        <!-- Callsign Filter Control [NEW - Issue 68] - dropdown only, no icon -->
+                        <div class="input-group input-group-sm ml-2" style="width: 130px;" title="Filter by Callsign">
+                            <select id="adminCallsignFilter" class="form-control font-weight-bold" style="font-size: 10px; height: 32px;">
                                 <option value="ALL">ALL CALLSIGNS</option>
                             </select>
                         </div>
@@ -490,7 +487,7 @@
                     <button type="button" class="btn btn-outline-success btn-sm px-3 shadow-sm font-weight-bold mr-2" id="btnDownloadGuardPdf" title="Download PDF">
                         <i class="fa fa-file-pdf-o mr-1"></i>PDF
                     </button>
-                    <button type="button" class="close ml-2" data-dismiss="modal" aria-label="Close" style="opacity: 1; outline: none; box-shadow: none; flex-shrink: 0;">
+                    <button type="button" class="close ml-3 pl-2" data-dismiss="modal" aria-label="Close" style="opacity: 1; outline: none; box-shadow: none; flex-shrink: 0;">
                         <span aria-hidden="true" style="font-size: 1.5rem; color: #000;">&times;</span>
                     </button>
                 </div>

--- a/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
+++ b/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
@@ -446,19 +446,13 @@
                             </select>
                         </div>
 
-                        <!-- Guard Filter Control [NEW] - icon only, no "FILTER" text -->
-                        <div class="input-group input-group-sm ml-2" style="width: 130px;" title="Filter by Guard">
-                            <div class="input-group-prepend">
-                                <span class="input-group-text bg-white border-right-0 text-muted small font-weight-bold"><i class="fa fa-filter"></i></span>
-                            </div>
-                            <select id="adminGuardFilter" class="form-control font-weight-bold" style="font-size: 10px; height: 32px; border-left: 0;">
+                        <!-- Filter Group [Issue 68] - Guard + Callsign filters in one neat outlined container -->
+                        <div class="d-flex align-items-center ml-2 border rounded bg-white overflow-hidden" style="height: 32px;" title="Filter Roster">
+                            <span class="text-muted pl-2 pr-1" style="font-size: 11px;"><i class="fa fa-filter"></i></span>
+                            <select id="adminGuardFilter" class="form-control font-weight-bold border-0 rounded-0 shadow-none h-100 pl-1" style="font-size: 10px; width: 105px;" title="Filter by Guard">
                                 <option value="ALL">ALL GUARDS</option>
                             </select>
-                        </div>
-
-                        <!-- Callsign Filter Control [NEW - Issue 68] - dropdown only, no icon -->
-                        <div class="input-group input-group-sm ml-2" style="width: 130px;" title="Filter by Callsign">
-                            <select id="adminCallsignFilter" class="form-control font-weight-bold" style="font-size: 10px; height: 32px;">
+                            <select id="adminCallsignFilter" class="form-control font-weight-bold border-0 border-left rounded-0 shadow-none h-100 pl-1" style="font-size: 10px; width: 115px;" title="Filter by Callsign">
                                 <option value="ALL">ALL CALLSIGNS</option>
                             </select>
                         </div>
@@ -466,11 +460,8 @@
 
                     <!-- Site Switcher (Admins & RO Editors) -->
                     <div id="guardRosterSiteSwitcher" class="d-none align-items-center mr-2">
-                        <div class="input-group input-group-sm mr-2" style="width: 140px;">
-                            <div class="input-group-prepend">
-                                <span class="input-group-text bg-white text-muted small font-weight-bold border-right-0" title="Client Type"><i class="fa fa-building"></i></span>
-                            </div>
-                            <select id="grModalClientType" class="form-control font-weight-bold text-truncate" style="font-size: 10px; height: 32px; border-left: 0;">
+                        <div class="input-group input-group-sm mr-2" style="width: 130px;">
+                            <select id="grModalClientType" class="form-control font-weight-bold text-truncate" style="font-size: 10px; height: 32px;">
                                 <option value="">Client Type</option>
                             </select>
                         </div>
@@ -481,10 +472,10 @@
                         </div>
                     </div>
 
-                    <button type="button" class="btn btn-outline-dark btn-sm px-3 shadow-sm font-weight-bold mr-2 d-none" id="btnToggleRosterEditMode" title="Toggle Edit Mode">
+                    <button type="button" class="btn btn-outline-dark btn-sm px-3 shadow-sm font-weight-bold mr-2 d-none text-nowrap" id="btnToggleRosterEditMode" style="height: 32px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center;" title="Toggle Edit Mode">
                         <i class="fa fa-pencil-square-o mr-1"></i>RO
                     </button>
-                    <button type="button" class="btn btn-outline-success btn-sm px-3 shadow-sm font-weight-bold mr-2" id="btnDownloadGuardPdf" title="Download PDF">
+                    <button type="button" class="btn btn-outline-success btn-sm px-3 shadow-sm font-weight-bold mr-2 text-nowrap d-inline-flex align-items-center justify-content-center" id="btnDownloadGuardPdf" style="height: 32px; flex-shrink: 0;" title="Download PDF">
                         <i class="fa fa-file-pdf-o mr-1"></i>PDF
                     </button>
                     <button type="button" class="close ml-3 pl-2" data-dismiss="modal" aria-label="Close" style="opacity: 1; outline: none; box-shadow: none; flex-shrink: 0;">

--- a/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
+++ b/CityWatch.Web/Pages/Guard/_GuardRosterModal.cshtml
@@ -455,6 +455,16 @@
                                 <option value="ALL">ALL GUARDS</option>
                             </select>
                         </div>
+
+                        <!-- Callsign Filter Control [NEW - Issue 68] -->
+                        <div class="input-group input-group-sm ml-2" style="width: 150px;" title="Filter by Callsign">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text bg-white border-right-0 text-muted small font-weight-bold"><i class="fa fa-microphone"></i></span>
+                            </div>
+                            <select id="adminCallsignFilter" class="form-control font-weight-bold" style="font-size: 10px; height: 32px; border-left: 0;">
+                                <option value="ALL">ALL CALLSIGNS</option>
+                            </select>
+                        </div>
                     </div>
 
                     <!-- Site Switcher (Admins & RO Editors) -->
@@ -1198,14 +1208,16 @@
         $('#btnConfirmGuardDownload').on('click', function() {
             var weeks = $('#guardPdfWeeks').val();
             var status = currentRosterStatus; // Send the status regardless of role
-            var url = '/roster/GuardRosterAction?handler=DownloadSiteRosterPdf' + 
-                '&siteId=' + currentGuardSiteId + 
-                '&startDate=' + guardRosterStartDate + 
-                '&weeks=' + weeks + 
-                '&includeFinancials=' + isAdminFinancialsOn + 
-                '&rateType=' + adminRateType + 
+            var url = '/roster/GuardRosterAction?handler=DownloadSiteRosterPdf' +
+                '&siteId=' + currentGuardSiteId +
+                '&startDate=' + guardRosterStartDate +
+                '&weeks=' + weeks +
+                '&includeFinancials=' + isAdminFinancialsOn +
+                '&rateType=' + adminRateType +
                 '&status=' + status +
-                '&includeSuppliers=' + isAdminSupplierOn;
+                '&includeSuppliers=' + isAdminSupplierOn +
+                '&guardFilter=' + encodeURIComponent($('#adminGuardFilter').val() || 'ALL') +
+                '&callsignFilter=' + encodeURIComponent($('#adminCallsignFilter').val() || 'ALL');
             window.open(url, '_blank');
             $('#guardDownloadFilterModal').modal('hide');
         });
@@ -1240,6 +1252,10 @@
         });
 
         $('#adminGuardFilter').on('change', function() {
+            applyGuardFilter();
+        });
+
+        $('#adminCallsignFilter').on('change', function() {
             applyGuardFilter();
         });
 
@@ -1598,7 +1614,31 @@
                     filterSelect.append('<option value="' + g.key + '">' + g.name + '</option>');
                 });
                 filterSelect.val(currentSelection || "ALL");
-                    var filterVal = filterSelect.val();
+                if (!filterSelect.val()) filterSelect.val("ALL"); // Selected guard not rostered this week
+                var filterVal = filterSelect.val();
+
+                // Update Callsign Filter Dropdown (Add unique callsigns found in this week's data) [Issue 68]
+                var callsignSelect = $('#adminCallsignFilter');
+                var currentCallsignSelection = callsignSelect.val();
+                callsignSelect.find('option:not([value="ALL"])').remove();
+
+                var filterCallsigns = [];
+                res.results.forEach(function(row) {
+                    row.days.forEach(function(dayShifts) {
+                        dayShifts.forEach(function(s) {
+                            if (s.callsignId && s.callsignName && !filterCallsigns.find(x => x.key === ("C" + s.callsignId))) {
+                                filterCallsigns.push({ key: "C" + s.callsignId, name: s.callsignName });
+                            }
+                        });
+                    });
+                });
+
+                filterCallsigns.sort((a,b) => a.name.localeCompare(b.name)).forEach(c => {
+                    callsignSelect.append('<option value="' + c.key + '">' + c.name + '</option>');
+                });
+                callsignSelect.val(currentCallsignSelection || "ALL");
+                if (!callsignSelect.val()) callsignSelect.val("ALL"); // Selected callsign not used this week
+                var callsignFilterVal = callsignSelect.val();
                 var grandTotalHours = 0;
                 var grandTotalCost = 0;
                 var dailyTotalHours = [0,0,0,0,0,0,0];
@@ -1724,6 +1764,10 @@
                             
                             // Apply Filtering
                             if (filterVal !== "ALL" && filterVal !== key) return;
+
+                            // Apply Callsign Filtering [Issue 68]
+                            var callsignKey = s.callsignId ? ("C" + s.callsignId) : "NONE";
+                            if (callsignFilterVal !== "ALL" && callsignFilterVal !== callsignKey) return;
 
                             var duration = parseFloat(s.durationHours);
                             var activeRate = (adminRateType == 'sell' ? s.sellRate : s.buyRate);

--- a/CityWatch.Web/Pages/roster/GuardRosterAction.cshtml.cs
+++ b/CityWatch.Web/Pages/roster/GuardRosterAction.cshtml.cs
@@ -238,7 +238,7 @@ namespace CityWatch.Web.Pages.roster
             return new JsonResult(new { results, holidays, siteState = site?.State, status, rosterGroupId });
         }
 
-        public async Task<IActionResult> OnGetDownloadSiteRosterPdf(int siteId, DateTime startDate, int weeks = 1, bool includeFinancials = false, string rateType = "guard", string status = "", bool includeSuppliers = false)
+        public async Task<IActionResult> OnGetDownloadSiteRosterPdf(int siteId, DateTime startDate, int weeks = 1, bool includeFinancials = false, string rateType = "guard", string status = "", bool includeSuppliers = false, string guardFilter = "ALL", string callsignFilter = "ALL")
         {
             if (string.IsNullOrEmpty(status))
             {
@@ -246,7 +246,7 @@ namespace CityWatch.Web.Pages.roster
                 status = statusObj?.Status ?? "Live";
             }
 
-            var pdfBytes = await _rosterReportGenerator.GenerateSiteRosterPdfAsync(siteId, startDate, weeks, includeFinancials, rateType, status, includeSuppliers);
+            var pdfBytes = await _rosterReportGenerator.GenerateSiteRosterPdfAsync(siteId, startDate, weeks, includeFinancials, rateType, status, includeSuppliers, guardFilter, callsignFilter);
             if (pdfBytes == null) return NotFound();
 
             string fileName = $"Site_Roster_{siteId}_{startDate:yyyyMMdd}.pdf";

--- a/CityWatch.Web/Services/GuardRosterReportGenerator.cs
+++ b/CityWatch.Web/Services/GuardRosterReportGenerator.cs
@@ -32,7 +32,7 @@ namespace CityWatch.Web.Services
     /// </summary>
     public interface IGuardRosterReportGenerator
     {
-        Task<byte[]> GenerateSiteRosterPdfAsync(int siteId, DateTime startDate, int weeks = 1, bool includeFinancials = false, string rateType = "guard", string status = "", bool includeSuppliers = false);
+        Task<byte[]> GenerateSiteRosterPdfAsync(int siteId, DateTime startDate, int weeks = 1, bool includeFinancials = false, string rateType = "guard", string status = "", bool includeSuppliers = false, string guardFilter = "ALL", string callsignFilter = "ALL");
     }
 
     public class GuardRosterReportGenerator : IGuardRosterReportGenerator
@@ -70,7 +70,7 @@ namespace CityWatch.Web.Services
             public bool IsPublicHoliday { get; set; }
         }
 
-        public async Task<byte[]> GenerateSiteRosterPdfAsync(int siteId, DateTime startDate, int weeks = 1, bool includeFinancials = false, string rateType = "guard", string status = "", bool includeSuppliers = false)
+        public async Task<byte[]> GenerateSiteRosterPdfAsync(int siteId, DateTime startDate, int weeks = 1, bool includeFinancials = false, string rateType = "guard", string status = "", bool includeSuppliers = false, string guardFilter = "ALL", string callsignFilter = "ALL")
         {
             var site = await _context.ClientSites.Include(s => s.ClientType).FirstOrDefaultAsync(x => x.Id == siteId);
             if (site == null) return null;
@@ -86,6 +86,24 @@ namespace CityWatch.Web.Services
                 .Include(x => x.PayRate)
                 .OrderBy(x => x.ShiftStart)
                 .ToListAsync();
+
+            // Apply the on-screen guard/callsign filters so the PDF matches the HTML grid [Issue 68].
+            // Keys mirror the modal JS: guard = "G{id}" (relief guard owns the shift) or "P{name}" for provider-only shifts; callsign = "C{id}".
+            if (!string.IsNullOrEmpty(guardFilter) && guardFilter != "ALL")
+            {
+                schedules = schedules.Where(s =>
+                {
+                    var effectiveGuardId = s.ReliefGuardId ?? s.GuardId;
+                    var effectiveName = s.ReliefGuard?.Name ?? s.ReliefProviderName ?? s.Guard?.Name ?? s.ProviderName ?? "Unassigned";
+                    var key = effectiveGuardId.HasValue ? ("G" + effectiveGuardId.Value) : ("P" + effectiveName);
+                    return key == guardFilter;
+                }).ToList();
+            }
+
+            if (!string.IsNullOrEmpty(callsignFilter) && callsignFilter != "ALL")
+            {
+                schedules = schedules.Where(s => (s.CallsignId.HasValue ? ("C" + s.CallsignId.Value) : "NONE") == callsignFilter).ToList();
+            }
 
             // Fetch Holidays for the range (including recurring match patterns)
             var holidayEvents = await _context.BroadcastBannerCalendarEvents


### PR DESCRIPTION
…sign filters

Adds a Callsign filter dropdown next to the existing Guard filter in the guard roster popup. It is populated from the callsigns rostered in the displayed week and refreshes on week change, same as the guard dropdown; both filters combine when rendering the grid and totals. Download PDF now passes the active guard and callsign filters to DownloadSiteRosterPdf so the generated PDF shows the same filtered result as the HTML view instead of the full roster. Also resets either filter to ALL when the previously selected option does not exist in the newly loaded week, preventing an empty grid.